### PR TITLE
Update special form completion candidates

### DIFF
--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -12,7 +12,8 @@
   )
 
 (def special-forms
-  '[def if do let quote var fn loop recur throw try dot new set!])
+  '#{& . case* catch def defrecord* deftype* do finally fn* if js* let*
+     letfn* loop* new ns quote recur set! throw try})
 
 (defn prefix-completions
   [prefix completions]


### PR DESCRIPTION
This uses the same set as tools.analyzer.js - see [here](https://github.com/clojure/tools.analyzer.js/blob/master/src/main/clojure/clojure/tools/analyzer/js.clj#L46) and [here](https://github.com/clojure/tools.analyzer/blob/master/src/main/clojure/clojure/tools/analyzer.clj#L228). This is the same as [cljs.analyzer](https://github.com/clojure/clojurescript/blob/master/src/clj/cljs/analyzer.clj#L382), but with `catch` and `finally` included.
